### PR TITLE
Switching to Recreate due to ReadWriteOnly PV

### DIFF
--- a/templates/dovecot/deployment.yaml
+++ b/templates/dovecot/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
 {{ include "mum.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.dovecot.deployment.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels: 
       app.kubernetes.io/name: {{ include "dovecot.deployment.name" . | quote }}


### PR DESCRIPTION
The default of a RollingUpdate causes an attachment issue if the new pod is launched on another worker.

The other worker cannot attach an RWO PV, since it's already attached.

Changing the update strategy to Recreate solves this.